### PR TITLE
Editing no weights should not crash

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -112,6 +112,7 @@ class AssignmentsController < ApplicationController
 
   def update_weights
     no_problems = true
+    params[:weight] = params[:weight] || {}
     assignments = Assignment.where(id: params[:weight].keys).map{|a| [a.id.to_s, a]}.to_h
     if assignments.count != params[:weight].keys.count
       missing = (params[:weight].keys.to_set - assignments.keys.to_set).to_a

--- a/test/controllers/assignments_controller_test.rb
+++ b/test/controllers/assignments_controller_test.rb
@@ -516,4 +516,16 @@ class AssignmentsControllerTest < ActionController::TestCase
 
     assert_redirected_to @cs101
   end
+
+  ##################################################
+  # Editing weights
+  ##################################################
+  test "should not break on editing no weights" do
+    sign_in @fred
+      post :update_weights, params: {
+             course_id: @cs101.id,
+            }
+    assert_redirected_to [@cs101, "assignments"]
+  end
+
 end


### PR DESCRIPTION
Went with this solution because `params[:weight]` is used a bunch later on. @blerner 