### PR TITLE
Remove the "impersonate" buttons for staff when not logged in as an admin

### DIFF
--- a/app/views/users/_table.html.erb
+++ b/app/views/users/_table.html.erb
@@ -71,7 +71,7 @@
         <td><%= maybe_link_user(link_to_students, user) %></td>
         <td><%= staff.detect{|u| u.user_id == user.id}.role.humanize %></td>
         <td><%= if user.id != current_user.id
-                  if current_user.site_admin? || current_user.professor_ever?
+                  if link_to_students
                     link_to 'Impersonate', impersonate_user_path(user), method: 'post'
                   end
                 else


### PR DESCRIPTION
The impersonate button only works for site admins, so it shouldn't display for anyone else.