### PR TITLE
Fix for #146: added check to prevent empty messages in files_subs

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -188,34 +188,34 @@ class GradesController < ApplicationController
     # there should be at most one grading allocation per user per assignment,
     # and at most one grading allocation should not be abandoned at any given time
     # but prefer to find the one for the current user, first
-    alloc = (allocs.find{|a| a.who_grades_id == current_user.id} || allocs.find{|a| !a.abandoned && a.grading_completed.nil?})
-    if alloc && alloc.grading_completed.nil?
-      if alloc.who_grades_id != current_user.id
-        alloc.abandoned = true
+      alloc = (allocs.find{|a| a.who_grades_id == current_user.id} || allocs.find{|a| !a.abandoned && a.grading_completed.nil?})
+      if alloc && alloc.grading_completed.nil?
+        if alloc.who_grades_id != current_user.id
+          alloc.abandoned = true
+          alloc.grading_completed = DateTime.now
+          alloc.save
+          alloc = GraderAllocation.new(
+            assignment: @assignment,
+            course: @course,
+            submission: @submission,
+            who_grades_id: current_user.id,
+            grading_assigned: alloc.grading_assigned)
+        end
+        alloc.abandoned = false
         alloc.grading_completed = DateTime.now
         alloc.save
-        alloc = GraderAllocation.new(
-          assignment: @assignment,
-          course: @course,
-          submission: @submission,
+      elsif alloc.nil?
+        GraderAllocation.create!(
+          abandoned: false,
           who_grades_id: current_user.id,
-          grading_assigned: alloc.grading_assigned)
+          grading_assigned: @assignment.due_date,
+          grading_completed: DateTime.now,
+          course: @course,
+          assignment: @assignment,
+          submission: @submission
+          )        
       end
-      alloc.abandoned = false
-      alloc.grading_completed = DateTime.now
-      alloc.save
-    elsif alloc.nil?
-      GraderAllocation.create!(
-        abandoned: false,
-        who_grades_id: current_user.id,
-        grading_assigned: @assignment.due_date,
-        grading_completed: DateTime.now,
-        course: @course,
-        assignment: @assignment,
-        submission: @submission
-      )        
     end
-  end
 
   def comment_to_inlinecomment(c)
     if c["id"]
@@ -227,41 +227,29 @@ class GradesController < ApplicationController
     if c["shouldDelete"]
       comment
     else
-      begin
-        comment.update!(submission_id: params[:submission_id],
-                        label: c["label"],
-                        filename: Upload.upload_path_for(c["file"]),
-                        line: c["line"],
-                        grade_id: @grade.id,
-                        user_id: current_user.id,
-                        severity: c["severity"],
-                        comment: c["comment"],
-                        weight: c["deduction"],
-                        suppressed: false,
-                        title: "",
-                        info: c["info"])
-        comment
-      rescue Exception => e
-        { id: c["id"], error: e }
-      end
+        begin
+          comment.update!(submission_id: params[:submission_id],
+            label: c["label"],
+            filename: Upload.upload_path_for(c["file"]),
+            line: c["line"],
+            grade_id: @grade.id,
+            user_id: current_user.id,
+            severity: c["severity"],
+            comment: c["comment"],
+            weight: c["deduction"],
+            suppressed: false,
+            title: "",
+            info: c["info"])
+          comment
+        rescue Exception => e
+          { id: c["id"], error: e }
+        end
     end
-  end
+  end  
 
   def question_to_inlinecomment(c)
-    comment = InlineComment.find_or_initialize_by(submission_id: params[:submission_id],
-                                                  grade_id: @grade.id,
-                                                  line: c["index"])
-    comment.update(label: "Graded question",
-                   filename: Upload.upload_path_for(@submission.upload.submission_path),
-                   severity: InlineComment.severities["info"],
-                   user_id: current_user.id,
-                   weight: c["score"],
-                   comment: c["comment"],
-                   suppressed: false,
-                   title: "",
-                   info: nil)
-    comment
-  end
+    @submission.grade_question!(current_user, @grade.id, c["comment"],c["index"], c["score"])
+  end   
 
   ###################################
   # Per-assignment-type actions, by action
@@ -478,9 +466,15 @@ class GradesController < ApplicationController
       f.json { autosave_comments(comments_params, :comment_to_inlinecomment) }
       f.html {
         save_all_comments(comments_params, :comment_to_inlinecomment)
-        mark_grading_allocation_completed
-        redirect_to course_assignment_submission_path(@course, @assignment, @submission),
-                    notice: "Comments saved; grading completed"
+        comments = InlineComment.where(submission_id: @submission.id)
+        if comments.any? {|a| a.comment.empty? } 
+          return redirect_back fallback_location: course_assignment_path(@course, @assignment),
+          alert: "Cannot mark grading complete when a comment has an empty message"
+        else  
+          mark_grading_allocation_completed
+          redirect_to course_assignment_submission_path(@course, @assignment, @submission),
+          notice: "Comments saved; grading completed"
+        end              
       }
     end
   end

--- a/app/models/submissions/exam_sub.rb
+++ b/app/models/submissions/exam_sub.rb
@@ -13,7 +13,7 @@ class ExamSub < Submission
                      severity: InlineComment.severities["info"],
                      user_id: (who_graded || self.user).id,
                      weight: score,
-                     comment: "",
+                     comment: "No comment needed",
                      suppressed: false,
                      title: "",
                      line: question,

--- a/app/models/submissions/questions_sub.rb
+++ b/app/models/submissions/questions_sub.rb
@@ -6,7 +6,7 @@ class QuestionsSub < Submission
   validate :check_time_taken
 
 
-  def grade_question!(who_graded, grade_id, message, question, score)
+  def grade_question(who_graded, grade_id, message, question, score)
     comment = InlineComment.find_or_initialize_by(submission: self,  grade_id: grade_id, line: question)
     comment.update(label: "Graded question",
                    filename: self.assignment.name,

--- a/app/models/submissions/questions_sub.rb
+++ b/app/models/submissions/questions_sub.rb
@@ -4,6 +4,22 @@ require 'audit'
 class QuestionsSub < Submission
   include SubmissionsHelper
   validate :check_time_taken
+
+
+  def grade_question!(who_graded, grade_id, message, question, score)
+    comment = InlineComment.find_or_initialize_by(submission: self,  grade_id: grade_id, line: question)
+    comment.update(label: "Graded question",
+                   filename: self.assignment.name,
+                   severity: InlineComment.severities["info"],
+                   user_id: (who_graded || self.user).id,
+                   weight: score,
+                   comment: message.empty? ?  "" : message,
+                   suppressed: false,
+                   title: "",
+                   info: nil)
+    comment
+  end
+
   def check_time_taken
     if self.assignment.request_time_taken && @time_taken.empty?
       self.errors.add(:base, "Please specify how long you have worked on this assignment")


### PR DESCRIPTION
Moved the logic for checking for empty comments to grades_controller#update_Files. Does a check to see if any of the comments have empty messages and if yes, prevent marking grading as complete until those empty messages are either filled in or deleted to not interfere with auto saving of comments. 

grades_controller#question_to_inlinecomment logic to the questions_sub model, should the logic for comment_to_inlinecomment also be in the model? 

Also for the Exam comment and Question comment not being blank, what would be some preferred non blank values?